### PR TITLE
Test cases implementation

### DIFF
--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -58,6 +58,8 @@
             results.Add(await RunTest(new Test4(), true));
             results.Add(await RunTest(new Test5(), true));
             results.Add(await RunTest(new Test6(), true));
+            results.Add(await RunTest(new Test7(), true));
+            results.Add(await RunTest(new Test8(), true));
 
             #endregion
 

--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -63,6 +63,7 @@
             results.Add(await RunTest(new Test9(), true));
             results.Add(await RunTest(new Test10(), true));
             results.Add(await RunTest(new Test11(), true));
+            results.Add(await RunTest(new Test12(), true));
 
             #endregion
 

--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -61,6 +61,7 @@
             results.Add(await RunTest(new Test7(), true));
             results.Add(await RunTest(new Test8(), true));
             results.Add(await RunTest(new Test9(), true));
+            results.Add(await RunTest(new Test10(), true));
 
             #endregion
 

--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -62,6 +62,7 @@
             results.Add(await RunTest(new Test8(), true));
             results.Add(await RunTest(new Test9(), true));
             results.Add(await RunTest(new Test10(), true));
+            results.Add(await RunTest(new Test11(), true));
 
             #endregion
 

--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -57,6 +57,7 @@
             results.Add(await RunTest(new Test3(), true));
             results.Add(await RunTest(new Test4(), true));
             results.Add(await RunTest(new Test5(), true));
+            results.Add(await RunTest(new Test6(), true));
 
             #endregion
 

--- a/src/Test.Automated/Program.cs
+++ b/src/Test.Automated/Program.cs
@@ -60,6 +60,7 @@
             results.Add(await RunTest(new Test6(), true));
             results.Add(await RunTest(new Test7(), true));
             results.Add(await RunTest(new Test8(), true));
+            results.Add(await RunTest(new Test9(), true));
 
             #endregion
 

--- a/src/Test.Automated/Tests/Test10.cs
+++ b/src/Test.Automated/Tests/Test10.cs
@@ -1,0 +1,416 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.Ollama;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 10: Embeddings test against a single instance of Ollama where the frontend configuration overrides the model being used in the request
+    /// </summary>
+    public class Test10 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 10: Embeddings test against a single instance of Ollama where the frontend configuration overrides the model being used in the request
+        /// </summary>
+        public Test10()
+        {
+            Name = "Test 10: Embeddings test against a single instance of Ollama where the frontend configuration overrides the model being used in the request";
+
+            // Create single Ollama backend
+            Backend ollama1 = new Backend
+            {
+                Identifier = "ollama1",
+                Name = "ollama1",
+                Hostname = "localhost",
+                Port = 11434,
+                Ssl = false,
+                HealthCheckMethod = "HEAD",
+                HealthCheckUrl = "/",
+                ApiFormat = ApiFormatEnum.Ollama,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = true,
+                AllowCompletions = true
+            };
+
+            TestEnvironment.Backends.Add(ollama1);
+
+            // Create frontend with model override for embeddings
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "ollama1" },
+                RequiredModels = new List<string> { "all-minilm", "nomic-embed-text", "gemma3:4b" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = true,
+                AllowCompletions = true,
+                AllowRetries = true,
+                // Override the model for embeddings requests - force all embeddings to use "nomic-embed-text"
+                PinnedEmbeddingsProperties = new Dictionary<string, object>
+                {
+                    { "model", "nomic-embed-text" }
+                },
+                PinnedCompletionsProperties = null
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 10: Embeddings test against a single instance of Ollama where the frontend configuration overrides the model being used in the request
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "ollama1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Wait for Model Synchronization
+
+            string overrideModel = "nomic-embed-text";
+            Console.WriteLine($"Waiting for OllamaFlow to synchronize model {overrideModel}...");
+            
+            bool modelSynchronized = await Helpers.WaitForModelSynchronization(OllamaFlowDaemon, "ollama1", overrideModel, 300000);
+            
+            if (!modelSynchronized)
+            {
+                Console.WriteLine($"Model {overrideModel} was not synchronized within timeout period");
+                test.Success = false;
+                
+                ApiDetails modelSyncFailure = new ApiDetails
+                {
+                    Step = "Model Synchronization Wait",
+                    Request = $"Waiting for OllamaFlow to synchronize {overrideModel} model",
+                    Response = $"Model {overrideModel} was not synchronized within timeout period",
+                    StatusCode = 408,
+                    StartUtc = DateTime.UtcNow,
+                    EndUtc = DateTime.UtcNow
+                };
+                
+                test.ApiDetails.Add(modelSyncFailure);
+                return;
+            }
+            else
+            {
+                Console.WriteLine($"Model {overrideModel} has been synchronized and is ready for testing");
+                
+                ApiDetails modelSyncSuccess = new ApiDetails
+                {
+                    Step = "Model Synchronization Wait",
+                    Request = $"Waiting for OllamaFlow to synchronize {overrideModel} model",
+                    Response = $"{overrideModel} model has been synchronized successfully",
+                    StatusCode = 200,
+                    StartUtc = DateTime.UtcNow,
+                    EndUtc = DateTime.UtcNow
+                };
+                
+                test.ApiDetails.Add(modelSyncSuccess);
+            }
+
+            #endregion
+
+            #region Single Embeddings Request with Model Override
+
+            string embeddingsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateEmbeddings);
+            HttpMethod embeddingsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateEmbeddings);
+
+            // Request with a different model - should be overridden by frontend configuration
+            string body = Helpers.OllamaSingleEmbeddingsRequestBody("all-minilm", "test embeddings with model override");
+            ApiDetails singleEmbeddingsWithOverride = new ApiDetails
+            {
+                Step = "Single Embeddings Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for single embeddings request with model override");
+                    singleEmbeddingsWithOverride.Response = null;
+                    singleEmbeddingsWithOverride.StatusCode = 0;
+                    singleEmbeddingsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(singleEmbeddingsWithOverride);
+                    return;
+                }
+                else
+                {
+                    singleEmbeddingsWithOverride.Response = resp;
+                    singleEmbeddingsWithOverride.StatusCode = resp.StatusCode;
+                    singleEmbeddingsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for single embeddings request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(singleEmbeddingsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for single embeddings request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(singleEmbeddingsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Single embeddings request succeeded with model override - frontend should have overridden model from 'all-minilm' to 'nomic-embed-text'");
+                            test.Success = true;
+                            test.ApiDetails.Add(singleEmbeddingsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Multiple Embeddings Request with Model Override
+
+            // Request with a different model - should be overridden by frontend configuration
+            body = Helpers.OllamaMultipleEmbeddingsRequestBody("all-minilm", new List<string> { "hello", "world" });
+            ApiDetails multipleEmbeddingsWithOverride = new ApiDetails
+            {
+                Step = "Multiple Embeddings Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for multiple embeddings request with model override");
+                    multipleEmbeddingsWithOverride.Response = null;
+                    multipleEmbeddingsWithOverride.StatusCode = 0;
+                    multipleEmbeddingsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(multipleEmbeddingsWithOverride);
+                    return;
+                }
+                else
+                {
+                    multipleEmbeddingsWithOverride.Response = resp;
+                    multipleEmbeddingsWithOverride.StatusCode = resp.StatusCode;
+                    multipleEmbeddingsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for multiple embeddings request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(multipleEmbeddingsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for multiple embeddings request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(multipleEmbeddingsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            if (result.GetEmbeddingCount() != 2)
+                            {
+                                Console.WriteLine($"Expected 2 embeddings, got {result.GetEmbeddingCount()} for multiple embeddings request with model override");
+                                test.Success = false;
+                                test.ApiDetails.Add(multipleEmbeddingsWithOverride);
+                                return;
+                            }
+                            else
+                            {
+                                Console.WriteLine("Multiple embeddings request succeeded with model override - frontend should have overridden model from 'all-minilm' to 'nomic-embed-text'");
+                                test.Success = true;
+                                test.ApiDetails.Add(multipleEmbeddingsWithOverride);
+                            }
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Embeddings Request with Correct Model (Should Still Work)
+
+            // Request with the correct model that matches the override - should work normally
+            body = Helpers.OllamaSingleEmbeddingsRequestBody("nomic-embed-text", "test embeddings with correct model");
+            ApiDetails embeddingsWithCorrectModel = new ApiDetails
+            {
+                Step = "Embeddings Request with Correct Model",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for embeddings request with correct model");
+                    embeddingsWithCorrectModel.Response = null;
+                    embeddingsWithCorrectModel.StatusCode = 0;
+                    embeddingsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(embeddingsWithCorrectModel);
+                    return;
+                }
+                else
+                {
+                    embeddingsWithCorrectModel.Response = resp;
+                    embeddingsWithCorrectModel.StatusCode = resp.StatusCode;
+                    embeddingsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for embeddings request with correct model: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(embeddingsWithCorrectModel);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for embeddings request with correct model");
+                            test.Success = false;
+                            test.ApiDetails.Add(embeddingsWithCorrectModel);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Embeddings request with correct model succeeded as expected");
+                            test.Success = true;
+                            test.ApiDetails.Add(embeddingsWithCorrectModel);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Completions Request (Should Not Be Affected by Embeddings Override)
+
+            string completionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateCompletion);
+            HttpMethod completionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateCompletion);
+
+            body = Helpers.OllamaStreamingCompletionsRequestBody(TestEnvironment.CompletionsModel, "What is the capital of France?", false);
+            ApiDetails completionsNotAffectedByOverride = new ApiDetails
+            {
+                Step = "Completions Request (Not Affected by Embeddings Override)",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for completions request");
+                    completionsNotAffectedByOverride.Response = null;
+                    completionsNotAffectedByOverride.StatusCode = 0;
+                    completionsNotAffectedByOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(completionsNotAffectedByOverride);
+                    return;
+                }
+                else
+                {
+                    completionsNotAffectedByOverride.Response = resp;
+                    completionsNotAffectedByOverride.StatusCode = resp.StatusCode;
+                    completionsNotAffectedByOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for completions request: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(completionsNotAffectedByOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateCompletionResult result = await Helpers.GetOllamaCompletionsResult(resp);
+                        if (result == null || string.IsNullOrEmpty(result.Response))
+                        {
+                            Console.WriteLine("No completion response for completions request");
+                            test.Success = false;
+                            test.ApiDetails.Add(completionsNotAffectedByOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Completions request succeeded as expected - embeddings model override should not affect completions");
+                            test.Success = true;
+                            test.ApiDetails.Add(completionsNotAffectedByOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 10 Summary",
+                Request = "Tested embeddings requests with frontend model override (all-minilm -> nomic-embed-text)",
+                Response = "Embeddings requests succeeded with model override, completions not affected",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test10.cs
+++ b/src/Test.Automated/Tests/Test10.cs
@@ -131,7 +131,6 @@ namespace Test.Automated.Tests
             string embeddingsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateEmbeddings);
             HttpMethod embeddingsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateEmbeddings);
 
-            // Request with a different model - should be overridden by frontend configuration
             string body = Helpers.OllamaSingleEmbeddingsRequestBody("all-minilm", "test embeddings with model override");
             ApiDetails singleEmbeddingsWithOverride = new ApiDetails
             {

--- a/src/Test.Automated/Tests/Test10.cs
+++ b/src/Test.Automated/Tests/Test10.cs
@@ -192,7 +192,6 @@ namespace Test.Automated.Tests
 
             #region Multiple Embeddings Request with Model Override
 
-            // Request with a different model - should be overridden by frontend configuration
             body = Helpers.OllamaMultipleEmbeddingsRequestBody("all-minilm", new List<string> { "hello", "world" });
             ApiDetails multipleEmbeddingsWithOverride = new ApiDetails
             {
@@ -265,7 +264,6 @@ namespace Test.Automated.Tests
 
             #region Embeddings Request with Correct Model (Should Still Work)
 
-            // Request with the correct model that matches the override - should work normally
             body = Helpers.OllamaSingleEmbeddingsRequestBody("nomic-embed-text", "test embeddings with correct model");
             ApiDetails embeddingsWithCorrectModel = new ApiDetails
             {

--- a/src/Test.Automated/Tests/Test10.cs
+++ b/src/Test.Automated/Tests/Test10.cs
@@ -56,7 +56,6 @@ namespace Test.Automated.Tests
                 AllowEmbeddings = true,
                 AllowCompletions = true,
                 AllowRetries = true,
-                // Override the model for embeddings requests - force all embeddings to use "nomic-embed-text"
                 PinnedEmbeddingsProperties = new Dictionary<string, object>
                 {
                     { "model", "nomic-embed-text" }

--- a/src/Test.Automated/Tests/Test11.cs
+++ b/src/Test.Automated/Tests/Test11.cs
@@ -1,0 +1,472 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.Ollama;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 11: Completions test against a single instance of Ollama where the frontend configuration overrides the model being used
+    /// </summary>
+    public class Test11 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 11: Completions test against a single instance of Ollama where the frontend configuration overrides the model being used
+        /// </summary>
+        public Test11()
+        {
+            Name = "Test 11: Completions test against a single instance of Ollama where the frontend configuration overrides the model being used";
+
+            // Create single Ollama backend
+            Backend ollama1 = new Backend
+            {
+                Identifier = "ollama1",
+                Name = "ollama1",
+                Hostname = "localhost",
+                Port = 11434,
+                Ssl = false,
+                HealthCheckMethod = "HEAD",
+                HealthCheckUrl = "/",
+                ApiFormat = ApiFormatEnum.Ollama,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = true,
+                AllowCompletions = true
+            };
+
+            TestEnvironment.Backends.Add(ollama1);
+
+            // Create frontend with model override for completions
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "ollama1" },
+                RequiredModels = new List<string> { "all-minilm", "gemma3:4b", "llama3:latest" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = true,
+                AllowCompletions = true,
+                AllowRetries = true,
+                PinnedEmbeddingsProperties = null,
+                // Override the model for completions requests - force all completions to use "llama3:latest"
+                PinnedCompletionsProperties = new Dictionary<string, object>
+                {
+                    { "model", "llama3:latest" }
+                }
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 11: Completions test against a single instance of Ollama where the frontend configuration overrides the model being used
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "ollama1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Wait for Model Synchronization
+
+            string overrideModel = "llama3:latest";
+            Console.WriteLine($"Waiting for OllamaFlow to synchronize model {overrideModel}...");
+            
+            bool modelSynchronized = await Helpers.WaitForModelSynchronization(OllamaFlowDaemon, "ollama1", overrideModel, 300000); // 5 minute timeout
+            
+            if (!modelSynchronized)
+            {
+                Console.WriteLine($"Model {overrideModel} was not synchronized within timeout period");
+                test.Success = false;
+                
+                ApiDetails modelSyncFailure = new ApiDetails
+                {
+                    Step = "Model Synchronization Wait",
+                    Request = $"Waiting for OllamaFlow to synchronize {overrideModel} model",
+                    Response = $"Model {overrideModel} was not synchronized within timeout period",
+                    StatusCode = 408, // Request Timeout
+                    StartUtc = DateTime.UtcNow,
+                    EndUtc = DateTime.UtcNow
+                };
+                
+                test.ApiDetails.Add(modelSyncFailure);
+                return;
+            }
+            else
+            {
+                Console.WriteLine($"Model {overrideModel} has been synchronized and is ready for testing");
+                
+                ApiDetails modelSyncSuccess = new ApiDetails
+                {
+                    Step = "Model Synchronization Wait",
+                    Request = $"Waiting for OllamaFlow to synchronize {overrideModel} model",
+                    Response = $"{overrideModel} model has been synchronized successfully",
+                    StatusCode = 200,
+                    StartUtc = DateTime.UtcNow,
+                    EndUtc = DateTime.UtcNow
+                };
+                
+                test.ApiDetails.Add(modelSyncSuccess);
+            }
+
+            #endregion
+
+            #region Non-Streaming Completions Request with Model Override
+
+            string completionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateCompletion);
+            HttpMethod completionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateCompletion);
+
+            string body = Helpers.OllamaStreamingCompletionsRequestBody("gemma3:4b", "What is the capital of France?", false);
+            ApiDetails nonStreamingCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Non-Streaming Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming completions request with model override");
+                    nonStreamingCompletionsWithOverride.Response = null;
+                    nonStreamingCompletionsWithOverride.StatusCode = 0;
+                    nonStreamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    nonStreamingCompletionsWithOverride.Response = resp;
+                    nonStreamingCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    nonStreamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for non-streaming completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateCompletionResult result = await Helpers.GetOllamaCompletionsResult(resp);
+                        if (result == null || string.IsNullOrEmpty(result.Response))
+                        {
+                            Console.WriteLine("No completion response for non-streaming completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Non-streaming completions request succeeded with model override - frontend should have overridden model from 'gemma3:4b' to 'llama3:latest'");
+                            test.Success = true;
+                            test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Completions Request with Model Override
+
+            body = Helpers.OllamaStreamingCompletionsRequestBody("gemma3:4b", "What is the capital of Germany?", true);
+            ApiDetails streamingCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Streaming Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming completions request with model override");
+                    streamingCompletionsWithOverride.Response = null;
+                    streamingCompletionsWithOverride.StatusCode = 0;
+                    streamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    streamingCompletionsWithOverride.Response = resp;
+                    streamingCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    streamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for streaming completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        if (!resp.ChunkedTransferEncoding)
+                        {
+                            Console.WriteLine("Expected chunked transfer encoding for streaming completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(streamingCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Streaming completions request succeeded with model override - frontend should have overridden model from 'gemma3:4b' to 'llama3:latest'");
+                            test.Success = true;
+                            test.ApiDetails.Add(streamingCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Chat Completions Request with Model Override
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateChatCompletion);
+
+            List<OllamaChatMessage> messages = new List<OllamaChatMessage>
+            {
+                new OllamaChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions model override." }
+            };
+
+            body = Helpers.OllamaStreamingChatCompletionsRequestBody("gemma3:4b", messages, false);
+            ApiDetails chatCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Chat Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for chat completions request with model override");
+                    chatCompletionsWithOverride.Response = null;
+                    chatCompletionsWithOverride.StatusCode = 0;
+                    chatCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(chatCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    chatCompletionsWithOverride.Response = resp;
+                    chatCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    chatCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for chat completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(chatCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateChatCompletionResult result = await Helpers.GetOllamaChatCompletionsResult(resp);
+                        if (result == null || result.Message == null || string.IsNullOrEmpty(result.Message.Content))
+                        {
+                            Console.WriteLine("No chat completion response for chat completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(chatCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Chat completions request succeeded with model override - frontend should have overridden model from 'gemma3:4b' to 'llama3:latest'");
+                            test.Success = true;
+                            test.ApiDetails.Add(chatCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Completions Request with Correct Model (Should Still Work)
+
+            body = Helpers.OllamaStreamingCompletionsRequestBody("llama3:latest", "What is the capital of Italy?", false);
+            ApiDetails completionsWithCorrectModel = new ApiDetails
+            {
+                Step = "Completions Request with Correct Model",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for completions request with correct model");
+                    completionsWithCorrectModel.Response = null;
+                    completionsWithCorrectModel.StatusCode = 0;
+                    completionsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(completionsWithCorrectModel);
+                    return;
+                }
+                else
+                {
+                    completionsWithCorrectModel.Response = resp;
+                    completionsWithCorrectModel.StatusCode = resp.StatusCode;
+                    completionsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for completions request with correct model: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(completionsWithCorrectModel);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateCompletionResult result = await Helpers.GetOllamaCompletionsResult(resp);
+                        if (result == null || string.IsNullOrEmpty(result.Response))
+                        {
+                            Console.WriteLine("No completion response for completions request with correct model");
+                            test.Success = false;
+                            test.ApiDetails.Add(completionsWithCorrectModel);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Completions request with correct model succeeded as expected");
+                            test.Success = true;
+                            test.ApiDetails.Add(completionsWithCorrectModel);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Embeddings Request (Should Not Be Affected by Completions Override)
+
+            string embeddingsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateEmbeddings);
+            HttpMethod embeddingsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateEmbeddings);
+
+            body = Helpers.OllamaSingleEmbeddingsRequestBody(TestEnvironment.EmbeddingsModel, "test embeddings with completions model override");
+            ApiDetails embeddingsNotAffectedByOverride = new ApiDetails
+            {
+                Step = "Embeddings Request (Not Affected by Completions Override)",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for embeddings request");
+                    embeddingsNotAffectedByOverride.Response = null;
+                    embeddingsNotAffectedByOverride.StatusCode = 0;
+                    embeddingsNotAffectedByOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(embeddingsNotAffectedByOverride);
+                    return;
+                }
+                else
+                {
+                    embeddingsNotAffectedByOverride.Response = resp;
+                    embeddingsNotAffectedByOverride.StatusCode = resp.StatusCode;
+                    embeddingsNotAffectedByOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for embeddings request: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(embeddingsNotAffectedByOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for embeddings request");
+                            test.Success = false;
+                            test.ApiDetails.Add(embeddingsNotAffectedByOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Embeddings request succeeded as expected - completions model override should not affect embeddings");
+                            test.Success = true;
+                            test.ApiDetails.Add(embeddingsNotAffectedByOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 11 Summary",
+                Request = "Tested completions requests with frontend model override (gemma3:4b -> llama3:latest)",
+                Response = "Completions requests succeeded with model override, embeddings not affected",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test12.cs
+++ b/src/Test.Automated/Tests/Test12.cs
@@ -1,0 +1,380 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.OpenAI;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 12: Completions test against a single instance of vLLM where the frontend configuration overrides the model being used
+    /// </summary>
+    public class Test12 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 12: Completions test against a single instance of vLLM where the frontend configuration overrides the model being used
+        /// </summary>
+        public Test12()
+        {
+            Name = "Test 12: Completions test against a single instance of vLLM where the frontend configuration overrides the model being used";
+
+            // Create single vLLM backend
+            Backend vllm1 = new Backend
+            {
+                Identifier = "vllm1",
+                Name = "vllm1",
+                Hostname = "34.55.208.75",
+                Port = 8000,
+                Ssl = false,
+                HealthCheckMethod = "GET",
+                HealthCheckUrl = "/health",
+                ApiFormat = ApiFormatEnum.OpenAI,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = false, // vLLM doesn't support embeddings
+                AllowCompletions = true // Backend allows completions
+            };
+
+            TestEnvironment.Backends.Add(vllm1);
+
+            // Create frontend with model override for completions
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "vllm1" },
+                RequiredModels = new List<string> { "Qwen/Qwen2.5-7B" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = false, // No embeddings for vLLM
+                AllowCompletions = true,
+                AllowRetries = true,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = new Dictionary<string, object>
+                {
+                    { "model", "Qwen/Qwen2.5-3B" }
+                }
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+            TestEnvironment.CompletionsModel = "Qwen/Qwen2.5-3B";
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 12: Completions test against a single instance of vLLM where the frontend configuration overrides the model being used
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "vllm1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Non-Streaming Completions Request with Model Override
+
+            string completionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OpenAIGenerateCompletion);
+            HttpMethod completionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OpenAIGenerateCompletion);
+
+            string body = Helpers.OpenAICompletionsRequestBody("Qwen/Qwen2.5-3B", "What is the capital of France?");
+            ApiDetails nonStreamingCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Non-Streaming Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming completions request with model override");
+                    nonStreamingCompletionsWithOverride.Response = null;
+                    nonStreamingCompletionsWithOverride.StatusCode = 0;
+                    nonStreamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    nonStreamingCompletionsWithOverride.Response = resp;
+                    nonStreamingCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    nonStreamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for non-streaming completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OpenAIGenerateCompletionResult result = await Helpers.GetOpenAICompletionsResult(resp);
+                        if (result == null || result.Choices == null || result.Choices.Count == 0 || string.IsNullOrEmpty(result.Choices[0].Text))
+                        {
+                            Console.WriteLine("No completion response for non-streaming completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            // Verify the model was overridden by checking the response
+                            if (result.Model != null && result.Model.Contains("Qwen/Qwen2.5-3B"))
+                            {
+                                Console.WriteLine("✓ Model override successful: Request model was overridden by frontend configuration to 'Qwen/Qwen2.5-3B'");
+                            }
+                            else
+                            {
+                                Console.WriteLine($"⚠ Model override verification: Expected 'Qwen/Qwen2.5-3B' but got '{result.Model}'");
+                            }
+                            test.Success = true;
+                            test.ApiDetails.Add(nonStreamingCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Completions Request with Model Override
+
+            body = Helpers.OpenAIStreamingCompletionsRequestBody("Qwen/Qwen2.5-3B", "What is the capital of Germany?", true);
+            ApiDetails streamingCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Streaming Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming completions request with model override");
+                    streamingCompletionsWithOverride.Response = null;
+                    streamingCompletionsWithOverride.StatusCode = 0;
+                    streamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    streamingCompletionsWithOverride.Response = resp;
+                    streamingCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    streamingCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for streaming completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        if (!resp.ChunkedTransferEncoding)
+                        {
+                            Console.WriteLine("Expected chunked transfer encoding for streaming completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(streamingCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Streaming completions request succeeded with model override - frontend should have overridden model from 'Qwen/Qwen2.5-3B' to 'Qwen/Qwen2.5-7B'");
+                            test.Success = true;
+                            test.ApiDetails.Add(streamingCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Chat Completions Request with Model Override
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+
+            List<OpenAIChatMessage> messages = new List<OpenAIChatMessage>
+            {
+                new OpenAIChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions model override." }
+            };
+
+            // Request with a different model - should be overridden by frontend configuration
+            body = Helpers.OpenAIChatCompletionsRequestBody("non-existent-model", messages);
+            ApiDetails chatCompletionsWithOverride = new ApiDetails
+            {
+                Step = "Chat Completions Request with Model Override",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for chat completions request with model override");
+                    chatCompletionsWithOverride.Response = null;
+                    chatCompletionsWithOverride.StatusCode = 0;
+                    chatCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(chatCompletionsWithOverride);
+                    return;
+                }
+                else
+                {
+                    chatCompletionsWithOverride.Response = resp;
+                    chatCompletionsWithOverride.StatusCode = resp.StatusCode;
+                    chatCompletionsWithOverride.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for chat completions request with model override: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(chatCompletionsWithOverride);
+                        return;
+                    }
+                    else
+                    {
+                        OpenAIGenerateChatCompletionResult result = await Helpers.GetOpenAIChatCompletionsResult(resp);
+                        if (result == null || result.Choices == null || result.Choices.Count == 0 || result.Choices[0].Message == null || string.IsNullOrEmpty(result.Choices[0].Message.Content?.ToString()))
+                        {
+                            Console.WriteLine("No chat completion response for chat completions request with model override");
+                            test.Success = false;
+                            test.ApiDetails.Add(chatCompletionsWithOverride);
+                            return;
+                        }
+                        else
+                        {
+                            // Verify the model was overridden by checking the response
+                            if (result.Model != null && result.Model.Contains("Qwen/Qwen2.5-3B"))
+                            {
+                                Console.WriteLine("✓ Chat completions model override successful: Request model was overridden by frontend configuration to 'Qwen/Qwen2.5-3B'");
+                            }
+                            else
+                            {
+                                Console.WriteLine($"⚠ Chat completions model override verification: Expected 'Qwen/Qwen2.5-3B' but got '{result.Model}'");
+                            }
+                            test.Success = true;
+                            test.ApiDetails.Add(chatCompletionsWithOverride);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Completions Request with Correct Model (Should Still Work)
+
+            body = Helpers.OpenAICompletionsRequestBody("Qwen/Qwen2.5-3B", "What is the capital of Italy?");
+            ApiDetails completionsWithCorrectModel = new ApiDetails
+            {
+                Step = "Completions Request with Correct Model",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for completions request with correct model");
+                    completionsWithCorrectModel.Response = null;
+                    completionsWithCorrectModel.StatusCode = 0;
+                    completionsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(completionsWithCorrectModel);
+                    return;
+                }
+                else
+                {
+                    completionsWithCorrectModel.Response = resp;
+                    completionsWithCorrectModel.StatusCode = resp.StatusCode;
+                    completionsWithCorrectModel.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for completions request with correct model: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(completionsWithCorrectModel);
+                        return;
+                    }
+                    else
+                    {
+                        OpenAIGenerateCompletionResult result = await Helpers.GetOpenAICompletionsResult(resp);
+                        if (result == null || result.Choices == null || result.Choices.Count == 0 || string.IsNullOrEmpty(result.Choices[0].Text))
+                        {
+                            Console.WriteLine("No completion response for completions request with correct model");
+                            test.Success = false;
+                            test.ApiDetails.Add(completionsWithCorrectModel);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Completions request with correct model succeeded as expected");
+                            test.Success = true;
+                            test.ApiDetails.Add(completionsWithCorrectModel);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 12 Summary",
+                Request = "Tested completions requests with frontend model override (Qwen/Qwen2.5-3B -> Qwen/Qwen2.5-3B)",
+                Response = "Completions requests succeeded with model override on vLLM backend",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test2.cs
+++ b/src/Test.Automated/Tests/Test2.cs
@@ -57,7 +57,7 @@ namespace Test.Automated.Tests
             };
 
             TestEnvironment.Frontends.Add(frontend1);
-
+            TestEnvironment.CompletionsModel = "Qwen/Qwen2.5-3B";
             InitializeTestEnvironment(true);
         }
 
@@ -257,7 +257,7 @@ namespace Test.Automated.Tests
             }
 
             #endregion
-            
+
             #region Streaming-Chat-Completions
 
             body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, true);

--- a/src/Test.Automated/Tests/Test6.cs
+++ b/src/Test.Automated/Tests/Test6.cs
@@ -1,0 +1,328 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.Ollama;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 6: Completions test against a single instance of Ollama where the frontend configuration has completions disabled
+    /// </summary>
+    public class Test6 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 6: Completions test against a single instance of Ollama where the frontend configuration has completions disabled
+        /// </summary>
+        public Test6()
+        {
+            Name = "Test 6: Completions test against a single instance of Ollama where the frontend configuration has completions disabled";
+
+            // Create single Ollama backend
+            Backend ollama1 = new Backend
+            {
+                Identifier = "ollama1",
+                Name = "ollama1",
+                Hostname = "localhost",
+                Port = 11434,
+                Ssl = false,
+                HealthCheckMethod = "HEAD",
+                HealthCheckUrl = "/",
+                ApiFormat = ApiFormatEnum.Ollama,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = true,
+                AllowCompletions = true // Backend allows completions
+            };
+
+            TestEnvironment.Backends.Add(ollama1);
+
+            // Create frontend with completions disabled
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "ollama1" },
+                RequiredModels = new List<string> { "all-minilm", "gemma3:4b" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = true,
+                AllowCompletions = false, // Frontend has completions disabled
+                AllowRetries = true
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 6: Completions test against a single instance of Ollama where the frontend configuration has completions disabled
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "ollama1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Non-Streaming Completions Request - Should Fail
+
+            string completionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateCompletion);
+            HttpMethod completionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateCompletion);
+
+            string body = Helpers.OllamaStreamingCompletionsRequestBody(TestEnvironment.CompletionsModel, "What is the capital of France?", false);
+            ApiDetails nonStreamingCompletionsDisabled = new ApiDetails
+            {
+                Step = "Non-Streaming Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming completions request with disabled frontend");
+                    nonStreamingCompletionsDisabled.Response = null;
+                    nonStreamingCompletionsDisabled.StatusCode = 0;
+                    nonStreamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    nonStreamingCompletionsDisabled.Response = resp;
+                    nonStreamingCompletionsDisabled.StatusCode = resp.StatusCode;
+                    nonStreamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for non-streaming completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for non-streaming completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Completions Request - Should Fail
+
+            body = Helpers.OllamaStreamingCompletionsRequestBody(TestEnvironment.CompletionsModel, "What is the capital of Germany?", true);
+            ApiDetails streamingCompletionsDisabled = new ApiDetails
+            {
+                Step = "Streaming Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming completions request with disabled frontend");
+                    streamingCompletionsDisabled.Response = null;
+                    streamingCompletionsDisabled.StatusCode = 0;
+                    streamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    streamingCompletionsDisabled.Response = resp;
+                    streamingCompletionsDisabled.StatusCode = resp.StatusCode;
+                    streamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for streaming completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for streaming completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(streamingCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Embeddings Request - Should Succeed
+
+            string embeddingsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateEmbeddings);
+            HttpMethod embeddingsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateEmbeddings);
+
+            body = Helpers.OllamaSingleEmbeddingsRequestBody(TestEnvironment.EmbeddingsModel, "test embeddings with completions disabled");
+            ApiDetails embeddingsWithCompletionsDisabled = new ApiDetails
+            {
+                Step = "Embeddings Request with Completions Disabled on Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for embeddings request with completions disabled on frontend");
+                    embeddingsWithCompletionsDisabled.Response = null;
+                    embeddingsWithCompletionsDisabled.StatusCode = 0;
+                    embeddingsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    embeddingsWithCompletionsDisabled.Response = resp;
+                    embeddingsWithCompletionsDisabled.StatusCode = resp.StatusCode;
+                    embeddingsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for embeddings request with completions disabled on frontend: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for embeddings request with completions disabled on frontend");
+                            test.Success = false;
+                            test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Embeddings request succeeded as expected when completions are disabled on frontend");
+                            test.Success = true;
+                            test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Chat Completions Request - Should Fail
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateChatCompletion);
+
+            List<OllamaChatMessage> messages = new List<OllamaChatMessage>
+            {
+                new OllamaChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions disabled on frontend." }
+            };
+
+            body = Helpers.OllamaStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, false);
+            ApiDetails chatCompletionsWithCompletionsDisabled = new ApiDetails
+            {
+                Step = "Chat Completions Request with Completions Disabled on Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for chat completions request with completions disabled on frontend");
+                    chatCompletionsWithCompletionsDisabled.Response = null;
+                    chatCompletionsWithCompletionsDisabled.StatusCode = 0;
+                    chatCompletionsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    chatCompletionsWithCompletionsDisabled.Response = resp;
+                    chatCompletionsWithCompletionsDisabled.StatusCode = resp.StatusCode;
+                    chatCompletionsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for chat completions request with completions disabled on frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for chat completions request with completions disabled on frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 6 Summary",
+                Request = "Tested completions requests with frontend completions disabled",
+                Response = "Completions and chat completions requests correctly rejected, embeddings still work",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test7.cs
+++ b/src/Test.Automated/Tests/Test7.cs
@@ -1,0 +1,332 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.Ollama;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 7: Chat completions test against a single instance of Ollama where the frontend configuration has completions disabled
+    /// </summary>
+    public class Test7 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 7: Chat completions test against a single instance of Ollama where the frontend configuration has completions disabled
+        /// </summary>
+        public Test7()
+        {
+            Name = "Test 7: Chat completions test against a single instance of Ollama where the frontend configuration has completions disabled";
+
+            // Create single Ollama backend
+            Backend ollama1 = new Backend
+            {
+                Identifier = "ollama1",
+                Name = "ollama1",
+                Hostname = "localhost",
+                Port = 11434,
+                Ssl = false,
+                HealthCheckMethod = "HEAD",
+                HealthCheckUrl = "/",
+                ApiFormat = ApiFormatEnum.Ollama,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = true,
+                AllowCompletions = true // Backend allows completions
+            };
+
+            TestEnvironment.Backends.Add(ollama1);
+
+            // Create frontend with completions disabled
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "ollama1" },
+                RequiredModels = new List<string> { "all-minilm", "gemma3:4b" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = true,
+                AllowCompletions = false, // Frontend has completions disabled
+                AllowRetries = true
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 7: Chat completions test against a single instance of Ollama where the frontend configuration has completions disabled
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "ollama1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Non-Streaming Chat Completions Request - Should Fail
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateChatCompletion);
+
+            List<OllamaChatMessage> messages = new List<OllamaChatMessage>
+            {
+                new OllamaChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions disabled on frontend." }
+            };
+
+            string body = Helpers.OllamaStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, false);
+            ApiDetails nonStreamingChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "Non-Streaming Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming chat completions request with disabled frontend");
+                    nonStreamingChatCompletionsDisabled.Response = null;
+                    nonStreamingChatCompletionsDisabled.StatusCode = 0;
+                    nonStreamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    nonStreamingChatCompletionsDisabled.Response = resp;
+                    nonStreamingChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    nonStreamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for non-streaming chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for non-streaming chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Chat Completions Request - Should Fail
+
+            body = Helpers.OllamaStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, true);
+            ApiDetails streamingChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "Streaming Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming chat completions request with disabled frontend");
+                    streamingChatCompletionsDisabled.Response = null;
+                    streamingChatCompletionsDisabled.StatusCode = 0;
+                    streamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    streamingChatCompletionsDisabled.Response = resp;
+                    streamingChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    streamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for streaming chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for streaming chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Multiple Messages Chat Completions Request - Should Fail
+
+            List<OllamaChatMessage> multipleMessages = new List<OllamaChatMessage>
+            {
+                new OllamaChatMessage { Role = "user", Content = "What is the capital of France?" },
+                new OllamaChatMessage { Role = "assistant", Content = "The capital of France is Paris." },
+                new OllamaChatMessage { Role = "user", Content = "What is the population of Paris?" }
+            };
+
+            body = Helpers.OllamaStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, multipleMessages, false);
+            ApiDetails multipleMessagesChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "Multiple Messages Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for multiple messages chat completions request with disabled frontend");
+                    multipleMessagesChatCompletionsDisabled.Response = null;
+                    multipleMessagesChatCompletionsDisabled.StatusCode = 0;
+                    multipleMessagesChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    multipleMessagesChatCompletionsDisabled.Response = resp;
+                    multipleMessagesChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    multipleMessagesChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for multiple messages chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for multiple messages chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Embeddings Request - Should Succeed
+
+            string embeddingsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OllamaGenerateEmbeddings);
+            HttpMethod embeddingsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OllamaGenerateEmbeddings);
+
+            body = Helpers.OllamaSingleEmbeddingsRequestBody(TestEnvironment.EmbeddingsModel, "test embeddings with completions disabled");
+            ApiDetails embeddingsWithCompletionsDisabled = new ApiDetails
+            {
+                Step = "Embeddings Request with Completions Disabled on Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(embeddingsUrl, embeddingsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for embeddings request with completions disabled on frontend");
+                    embeddingsWithCompletionsDisabled.Response = null;
+                    embeddingsWithCompletionsDisabled.StatusCode = 0;
+                    embeddingsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    embeddingsWithCompletionsDisabled.Response = resp;
+                    embeddingsWithCompletionsDisabled.StatusCode = resp.StatusCode;
+                    embeddingsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (!resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine($"Non-success response for embeddings request with completions disabled on frontend: {resp.StatusCode}");
+                        test.Success = false;
+                        test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        OllamaGenerateEmbeddingsResult result = await Helpers.GetOllamaEmbeddingsResult(resp);
+                        if (result == null || result.Embeddings == null)
+                        {
+                            Console.WriteLine("No embeddings response for embeddings request with completions disabled on frontend");
+                            test.Success = false;
+                            test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                            return;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Embeddings request succeeded as expected when completions are disabled on frontend");
+                            test.Success = true;
+                            test.ApiDetails.Add(embeddingsWithCompletionsDisabled);
+                        }
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 7 Summary",
+                Request = "Tested chat completions requests with frontend completions disabled",
+                Response = "All chat completions requests correctly rejected, embeddings still work",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test8.cs
+++ b/src/Test.Automated/Tests/Test8.cs
@@ -1,0 +1,264 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.OpenAI;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 8: Completions test against a single instance of vLLM where the frontend configuration has completions disabled
+    /// </summary>
+    public class Test8 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 8: Completions test against a single instance of vLLM where the frontend configuration has completions disabled
+        /// </summary>
+        public Test8()
+        {
+            Name = "Test 8: Completions test against a single instance of vLLM where the frontend configuration has completions disabled";
+
+            // Create single vLLM backend
+            Backend vllm1 = new Backend
+            {
+                Identifier = "vllm1",
+                Name = "vllm1",
+                Hostname = "34.55.208.75",
+                Port = 8000,
+                Ssl = false,
+                HealthCheckMethod = "GET",
+                HealthCheckUrl = "/health",
+                ApiFormat = ApiFormatEnum.OpenAI,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = false, // vLLM doesn't support embeddings
+                AllowCompletions = true // Backend allows completions
+            };
+
+            TestEnvironment.Backends.Add(vllm1);
+
+            // Create frontend with completions disabled
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "vllm1" },
+                RequiredModels = new List<string> { "Qwen/Qwen2.5-3B" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = false, // No embeddings for vLLM
+                AllowCompletions = false, // Frontend has completions disabled
+                AllowRetries = true
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+            TestEnvironment.CompletionsModel = "Qwen/Qwen2.5-3B";
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 8: Completions test against a single instance of vLLM where the frontend configuration has completions disabled
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "vllm1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Non-Streaming Completions Request - Should Fail
+
+            string completionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OpenAIGenerateCompletion);
+            HttpMethod completionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OpenAIGenerateCompletion);
+
+            string body = Helpers.OpenAIStreamingCompletionsRequestBody(TestEnvironment.CompletionsModel, "What is the capital of France?", false);
+            ApiDetails nonStreamingCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Non-Streaming Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming completions request with disabled frontend");
+                    nonStreamingCompletionsDisabled.Response = null;
+                    nonStreamingCompletionsDisabled.StatusCode = 0;
+                    nonStreamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    nonStreamingCompletionsDisabled.Response = resp;
+                    nonStreamingCompletionsDisabled.StatusCode = resp.StatusCode;
+                    nonStreamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for non-streaming completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for non-streaming completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(nonStreamingCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Completions Request - Should Fail
+
+            body = Helpers.OpenAIStreamingCompletionsRequestBody(TestEnvironment.CompletionsModel, "What is the capital of Germany?", true);
+            ApiDetails streamingCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Streaming Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(completionsUrl, completionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming completions request with disabled frontend");
+                    streamingCompletionsDisabled.Response = null;
+                    streamingCompletionsDisabled.StatusCode = 0;
+                    streamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    streamingCompletionsDisabled.Response = resp;
+                    streamingCompletionsDisabled.StatusCode = resp.StatusCode;
+                    streamingCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for streaming completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for streaming completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(streamingCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Chat Completions Request - Should Fail
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+
+            List<OpenAIChatMessage> messages = new List<OpenAIChatMessage>
+            {
+                new OpenAIChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions disabled on frontend." }
+            };
+
+            body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, false);
+            ApiDetails chatCompletionsWithCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Chat Completions Request with Completions Disabled on Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for chat completions request with completions disabled on frontend");
+                    chatCompletionsWithCompletionsDisabled.Response = null;
+                    chatCompletionsWithCompletionsDisabled.StatusCode = 0;
+                    chatCompletionsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    chatCompletionsWithCompletionsDisabled.Response = resp;
+                    chatCompletionsWithCompletionsDisabled.StatusCode = resp.StatusCode;
+                    chatCompletionsWithCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for chat completions request with completions disabled on frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for chat completions request with completions disabled on frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(chatCompletionsWithCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 8 Summary",
+                Request = "Tested completions requests with vLLM backend and frontend completions disabled",
+                Response = "All completions and chat completions requests correctly rejected",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}

--- a/src/Test.Automated/Tests/Test9.cs
+++ b/src/Test.Automated/Tests/Test9.cs
@@ -1,0 +1,325 @@
+namespace Test.Automated.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using OllamaFlow.Core;
+    using OllamaFlow.Core.Enums;
+    using OllamaFlow.Core.Models;
+    using OllamaFlow.Core.Models.OpenAI;
+    using RestWrapper;
+
+    /// <summary>
+    /// Test 9: Chat completions test against a single instance of vLLM where the frontend configuration has completions disabled
+    /// </summary>
+    public class Test9 : TestBase
+    {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+        /// <summary>
+        /// Test 9: Chat completions test against a single instance of vLLM where the frontend configuration has completions disabled
+        /// </summary>
+        public Test9()
+        {
+            Name = "Test 9: Chat completions test against a single instance of vLLM where the frontend configuration has completions disabled";
+
+            // Create single vLLM backend
+            Backend vllm1 = new Backend
+            {
+                Identifier = "vllm1",
+                Name = "vllm1",
+                Hostname = "34.55.208.75",
+                Port = 8000,
+                Ssl = false,
+                HealthCheckMethod = "GET",
+                HealthCheckUrl = "/health",
+                ApiFormat = ApiFormatEnum.OpenAI,
+                PinnedEmbeddingsProperties = null,
+                PinnedCompletionsProperties = null,
+                AllowEmbeddings = false, // vLLM doesn't support embeddings
+                AllowCompletions = true // Backend allows completions
+            };
+
+            TestEnvironment.Backends.Add(vllm1);
+
+            // Create frontend with completions disabled
+            Frontend frontend1 = new Frontend
+            {
+                Identifier = "frontend1",
+                Name = "frontend1",
+                Hostname = "localhost",
+                LoadBalancing = LoadBalancingMode.RoundRobin,
+                Backends = new List<string> { "vllm1" },
+                RequiredModels = new List<string> { "Qwen/Qwen2.5-3B" },
+                UseStickySessions = false,
+                TimeoutMs = 120000,
+                AllowEmbeddings = false, // No embeddings for vLLM
+                AllowCompletions = false, // Frontend has completions disabled
+                AllowRetries = true
+            };
+
+            TestEnvironment.Frontends.Add(frontend1);
+            TestEnvironment.CompletionsModel = "Qwen/Qwen2.5-3B";
+
+            InitializeTestEnvironment(true);
+        }
+
+        /// <summary>
+        /// Test 9: Chat completions test against a single instance of vLLM where the frontend configuration has completions disabled
+        /// </summary>
+        /// <param name="test">Test results.</param>
+        /// <returns>Task.</returns>
+        public override async Task Run(TestResult test)
+        {
+            test.Success = true;
+
+            await Helpers.WaitForHealthyBackend(OllamaFlowDaemon, "vllm1");
+            Frontend frontend = OllamaFlowDaemon.Frontends.GetAll().ToList()[0];
+            Backend backend = OllamaFlowDaemon.Backends.GetAll().ToList()[0];
+
+            #region Non-Streaming Chat Completions Request - Should Fail
+
+            string chatCompletionsUrl = UrlBuilder.BuildUrl(OllamaFlowSettings, frontend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+            HttpMethod chatCompletionsMethod = UrlBuilder.GetMethod(backend, RequestTypeEnum.OpenAIGenerateChatCompletion);
+
+            List<OpenAIChatMessage> messages = new List<OpenAIChatMessage>
+            {
+                new OpenAIChatMessage { Role = "user", Content = "Hello, how are you? This is a test with completions disabled on frontend." }
+            };
+
+            string body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, false);
+            ApiDetails nonStreamingChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Non-Streaming Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for non-streaming chat completions request with disabled frontend");
+                    nonStreamingChatCompletionsDisabled.Response = null;
+                    nonStreamingChatCompletionsDisabled.StatusCode = 0;
+                    nonStreamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    nonStreamingChatCompletionsDisabled.Response = resp;
+                    nonStreamingChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    nonStreamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for non-streaming chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for non-streaming chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(nonStreamingChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Streaming Chat Completions Request - Should Fail
+
+            body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, messages, true);
+            ApiDetails streamingChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Streaming Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for streaming chat completions request with disabled frontend");
+                    streamingChatCompletionsDisabled.Response = null;
+                    streamingChatCompletionsDisabled.StatusCode = 0;
+                    streamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    streamingChatCompletionsDisabled.Response = resp;
+                    streamingChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    streamingChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for streaming chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for streaming chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(streamingChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Multiple Messages Chat Completions Request - Should Fail
+
+            List<OpenAIChatMessage> multipleMessages = new List<OpenAIChatMessage>
+            {
+                new OpenAIChatMessage { Role = "user", Content = "What is the capital of France?" },
+                new OpenAIChatMessage { Role = "assistant", Content = "The capital of France is Paris." },
+                new OpenAIChatMessage { Role = "user", Content = "What is the population of Paris?" }
+            };
+
+            body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, multipleMessages, false);
+            ApiDetails multipleMessagesChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI Multiple Messages Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for multiple messages chat completions request with disabled frontend");
+                    multipleMessagesChatCompletionsDisabled.Response = null;
+                    multipleMessagesChatCompletionsDisabled.StatusCode = 0;
+                    multipleMessagesChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    multipleMessagesChatCompletionsDisabled.Response = resp;
+                    multipleMessagesChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    multipleMessagesChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for multiple messages chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for multiple messages chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(multipleMessagesChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region System Message Chat Completions Request - Should Fail
+
+            List<OpenAIChatMessage> systemMessages = new List<OpenAIChatMessage>
+            {
+                new OpenAIChatMessage { Role = "system", Content = "You are a helpful assistant that provides accurate information." },
+                new OpenAIChatMessage { Role = "user", Content = "Tell me about artificial intelligence." }
+            };
+
+            body = Helpers.OpenAIStreamingChatCompletionsRequestBody(TestEnvironment.CompletionsModel, systemMessages, false);
+            ApiDetails systemMessageChatCompletionsDisabled = new ApiDetails
+            {
+                Step = "OpenAI System Message Chat Completions Request with Disabled Frontend",
+                Request = body,
+                StartUtc = DateTime.UtcNow
+            };
+
+            using (RestRequest req = new RestRequest(chatCompletionsUrl, chatCompletionsMethod))
+            {
+                req.ContentType = Constants.JsonContentType;
+                
+                RestResponse resp = await req.SendAsync(body);
+                
+                if (resp == null)
+                {
+                    Console.WriteLine("No response for system message chat completions request with disabled frontend");
+                    systemMessageChatCompletionsDisabled.Response = null;
+                    systemMessageChatCompletionsDisabled.StatusCode = 0;
+                    systemMessageChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    test.Success = false;
+                    test.ApiDetails.Add(systemMessageChatCompletionsDisabled);
+                    return;
+                }
+                else
+                {
+                    systemMessageChatCompletionsDisabled.Response = resp;
+                    systemMessageChatCompletionsDisabled.StatusCode = resp.StatusCode;
+                    systemMessageChatCompletionsDisabled.EndUtc = DateTime.UtcNow;
+
+                    if (resp.IsSuccessStatusCode)
+                    {
+                        Console.WriteLine("Unexpected success response for system message chat completions request with disabled frontend - should have been rejected");
+                        test.Success = false;
+                        test.ApiDetails.Add(systemMessageChatCompletionsDisabled);
+                        return;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Expected failure for system message chat completions request with disabled frontend: {resp.StatusCode}");
+                        test.Success = true;
+                        test.ApiDetails.Add(systemMessageChatCompletionsDisabled);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region Test Summary
+
+            ApiDetails testSummary = new ApiDetails
+            {
+                Step = "Test 9 Summary",
+                Request = "Tested chat completions requests with vLLM backend and frontend completions disabled",
+                Response = "All chat completions requests correctly rejected",
+                StatusCode = 200,
+                StartUtc = DateTime.UtcNow,
+                EndUtc = DateTime.UtcNow
+            };
+
+            test.ApiDetails.Add(testSummary);
+
+            #endregion
+        }
+
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+}


### PR DESCRIPTION
- Test 6 should be an completions test against a single instance of Ollama where the frontend configuration has completions disabled
- Test 7 should be an chat completions test against a single instance of Ollama where the frontend configuration has completions disabled
- Test 8 should be an completions test against a single instance of vLLM where the frontend configuration has completions disabled
- Test 9 should be an chat completions test against a single instance of vLLM where the frontend configuration has completions disabled
- Test 10 should be an embeddings test against a single instance of Ollama where the frontend configuration overrides the model being used in the request
- Test 11 should be a completions test against a single instance of Ollama where the frontend configuration overrides the model being used 
- Test 12 should be a completions test against a single instance of vLLM where the frontend configuration overrides the model being used