### PR TITLE
Update GatewayService.cs

### DIFF
--- a/src/OllamaFlow.Core/Services/GatewayService.cs
+++ b/src/OllamaFlow.Core/Services/GatewayService.cs
@@ -640,6 +640,9 @@
 
                     #endregion
 
+                    // apply frontend timeout configuration
+                    restRequest.TimeoutMilliseconds = frontend.TimeoutMs;
+
                     #region Send
 
                     // _Logging.Debug($"{_Header}sending request to backend {backend.Identifier} for frontend {frontend.Identifier} using {method} {url}{Environment.NewLine}{requestBody}");


### PR DESCRIPTION
Though frontend has `TimeoutMs` configuration, it seems not to be utilized in the RestRequest.SendAsync.
Then I added just a line to make it work.

As far as I tested, this modification works fine for the Ollama backend.